### PR TITLE
class 기반 dark 모드 적용 (storybook, ui)

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,26 +1,24 @@
-import type { StorybookConfig } from '@storybook/react-vite';
+import type { StorybookConfig } from "@storybook/react-vite";
 
-import { join, dirname } from "path"
+import { dirname, join } from "path";
 
 /**
-* This function is used to resolve the absolute path of a package.
-* It is needed in projects that use Yarn PnP or are set up within a monorepo.
-*/
+ * This function is used to resolve the absolute path of a package.
+ * It is needed in projects that use Yarn PnP or are set up within a monorepo.
+ */
 function getAbsolutePath(value: string) {
-  return dirname(require.resolve(join(value, 'package.json')))
+  return dirname(require.resolve(join(value, "package.json")));
 }
 const config: StorybookConfig = {
-  "stories": [
-    "../stories/**/*.mdx",
-    "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+  stories: ["../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  addons: [
+    getAbsolutePath("@storybook/addon-essentials"),
+    getAbsolutePath("@storybook/addon-interactions"),
+    getAbsolutePath("@storybook/addon-themes"),
   ],
-  "addons": [
-    getAbsolutePath('@storybook/addon-essentials'),
-    getAbsolutePath('@storybook/addon-interactions')
-  ],
-  "framework": {
-    "name": getAbsolutePath('@storybook/react-vite'),
-    "options": {}
-  }
+  framework: {
+    name: getAbsolutePath("@storybook/react-vite"),
+    options: {},
+  },
 };
 export default config;

--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -1,4 +1,5 @@
-import type { Preview } from '@storybook/react'
+import { withThemeByClassName } from "@storybook/addon-themes";
+import type { Preview, ReactRenderer } from "@storybook/react";
 
 import "../global.css";
 
@@ -6,11 +7,20 @@ const preview: Preview = {
   parameters: {
     controls: {
       matchers: {
-       color: /(background|color)$/i,
-       date: /Date$/i,
+        color: /(background|color)$/i,
+        date: /Date$/i,
       },
     },
   },
+  decorators: [
+    withThemeByClassName<ReactRenderer>({
+      themes: {
+        light: "",
+        dark: "dark",
+      },
+      defaultTheme: "light",
+    }),
+  ],
 };
 
 export default preview;

--- a/apps/storybook/global.css
+++ b/apps/storybook/global.css
@@ -1,1 +1,9 @@
 @import "tailwindcss";
+
+:root {
+  @apply bg-neutral-100;
+}
+
+.dark {
+  @apply bg-neutral-900;
+}

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -16,6 +16,7 @@
     "@eslint/js": "^9.22.0",
     "@storybook/addon-essentials": "^8.6.12",
     "@storybook/addon-interactions": "^8.6.12",
+    "@storybook/addon-themes": "^8.6.12",
     "@storybook/blocks": "^8.6.12",
     "@storybook/react": "^8.6.12",
     "@storybook/react-vite": "^8.6.12",

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -41,7 +41,7 @@ packages/ui
 This package can be imported and used in other apps (e.g., web, docs) within the monorepo as follows:
 
 ```tsx
-import { Button } from '@ui-kit/ui';
+import { Button } from "@ui-kit/ui";
 
 function App() {
   return <Button>Button</Button>;
@@ -62,4 +62,4 @@ pnpm build
 - [Vite Official Docs](https://vitejs.dev/)
 - [TailwindCSS Official Docs](https://tailwindcss.com/docs)
 - [Storybook Official Docs](https://storybook.js.org/docs/react/get-started/introduction)
-- [TypeScript Official Docs](https://www.typescriptlang.org/) 
+- [TypeScript Official Docs](https://www.typescriptlang.org/)

--- a/packages/ui/lib/components/Button/index.tsx
+++ b/packages/ui/lib/components/Button/index.tsx
@@ -7,7 +7,13 @@ export function Button({
   ...props
 }: ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
-    <button className={cn("bg-red-500", className)} {...props}>
+    <button
+      className={cn(
+        "bg-red-700 text-red-100 dark:bg-red-300 dark:text-red-900",
+        className
+      )}
+      {...props}
+    >
       {children}
     </button>
   );

--- a/packages/ui/styles/global.css
+++ b/packages/ui/styles/global.css
@@ -1,1 +1,3 @@
 @import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       '@storybook/addon-interactions':
         specifier: ^8.6.12
         version: 8.6.12(storybook@8.6.12(prettier@3.5.3))
+      '@storybook/addon-themes':
+        specifier: ^8.6.12
+        version: 8.6.12(storybook@8.6.12(prettier@3.5.3))
       '@storybook/blocks':
         specifier: ^8.6.12
         version: 8.6.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))
@@ -1013,6 +1016,11 @@ packages:
 
   '@storybook/addon-outline@8.6.12':
     resolution: {integrity: sha512-1ylwm+n1s40S91No0v9T4tCjZORu3GbnjINlyjYTDLLhQHyBQd3nWR1Y1eewU4xH4cW9SnSLcMQFS/82xHqU6A==}
+    peerDependencies:
+      storybook: ^8.6.12
+
+  '@storybook/addon-themes@8.6.12':
+    resolution: {integrity: sha512-eqE40MUKTz9lLEOusXjRuDC7DwCSIwlgEnlbvhhEEme8IeKf2di6yvlhenY4nn5QfkUwY1POnZxfJ2OpXj0gqQ==}
     peerDependencies:
       storybook: ^8.6.12
 
@@ -4373,6 +4381,11 @@ snapshots:
   '@storybook/addon-outline@8.6.12(storybook@8.6.12(prettier@3.5.3))':
     dependencies:
       '@storybook/global': 5.0.0
+      storybook: 8.6.12(prettier@3.5.3)
+      ts-dedent: 2.2.0
+
+  '@storybook/addon-themes@8.6.12(storybook@8.6.12(prettier@3.5.3))':
+    dependencies:
       storybook: 8.6.12(prettier@3.5.3)
       ts-dedent: 2.2.0
 


### PR DESCRIPTION
TailwindCSS를 이용한 class 기반 다크모드 테마 적용

## 작업 내용

- `@storybook/addon-themes` 애드온 추가 및 적용
- ui, storybook 프로젝트에 테마 적용
- 테스트용 Button 컴포넌트에 다크모드 적용
- 스토리북 설정 main.ts 에 mdx 파일 제외

## 테스트

- 스토리북 실행
  - 터보레포 사용: `pnpm i && pnpm dev --filter storybook`
  - pnpm 사용: `cd packages/ui && pnpm build`, `cd apps/storybook && pnpm dev`
- 상단 툴바의 light/dark theme 버튼 클릭
- Button 컴포넌트에 light/dark 테마가 반영되는지 확인

Closes #3 